### PR TITLE
docs: 修复失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,6 @@ Thanks to [Tencent Cloud Lighthouse](https://cloud.tencent.com/product/lighthous
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://www.star-history.com/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://star-history.dera.page/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
 
 </div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -698,6 +698,6 @@ STT 支持两级配置，按优先级查找：
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://www.star-history.com/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://star-history.dera.page/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
 
 </div>


### PR DESCRIPTION
当前 README 中的 Star History 图表由于 GitHub API 限制已经无法正常加载，严重影响项目展示效果。

本 PR 将 README.md 与 README.zh.md 中的 Star History 图表地址更新为可用的新域名 star-history.dera.page，该服务使用无需 API Token 的数据源，确保图表恢复展示。

仅更新图表链接，不影响其他内容。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English and Chinese README files.
  * Charts now use the new Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->