### PR TITLE
fix: route CLI message send through the OpenClaw gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- Declare `outbound.deliveryMode: "gateway"` so `openclaw message send` is routed through the OpenClaw gateway process that owns the live WebSocket. Fixes CLI `Bot "default" not running` when the gateway is connected ([#298](https://github.com/tencent-connect/openclaw-qqbot/issues/298)).
+- Clarify the in-process "bot not running" error so it no longer implies the gateway bot is down.
+
+---
+
 ## [2.0.3] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -4,6 +4,15 @@
 
 格式参考 [Keep a Changelog](https://keepachangelog.com/)。
 
+## [Unreleased]
+
+### 修复
+
+- 将 `outbound.deliveryMode` 改为 `"gateway"`，使 `openclaw message send` 走持有活 WebSocket 的 OpenClaw gateway 进程，修复 gateway 已连接时 CLI 仍报 `Bot "default" not running`（[#298](https://github.com/tencent-connect/openclaw-qqbot/issues/298)）。
+- 澄清进程内「bot not running」文案，避免被理解成 gateway 里的机器人没在跑。
+
+---
+
 ## [2.0.3] - 2026-08-25
 
 ### 修复

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -8,6 +8,7 @@
 import os from 'node:os';
 import type { QQBot } from '@tencent-connect/qqbot-nodejs';
 import { getGateway } from './outbound/outbound-service.js';
+import { botNotRunningMessage } from './outbound/errors.js';
 import { getPackageVersion } from './utils/pkg-version.js';
 
 
@@ -45,7 +46,7 @@ export function buildUserAgent(suffix?: string): string {
 export function getBotForAccount(accountId: string): QQBot {
   const gw = getGateway(accountId);
   if (!gw) {
-    throw new Error(`[qqbot] Bot "${accountId}" not running — gateway not started`);
+    throw new Error(`[qqbot] ${botNotRunningMessage(accountId)}`);
   }
   return gw.bot;
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -180,7 +180,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
 
   // ── 出站 ──
   outbound: {
-    deliveryMode: 'direct' as const,
+    deliveryMode: 'gateway' as const,
     sanitizeText: ({ text }: { text: string; payload: any }) => sanitizeQQBotText(text),
     chunker: (text, limit) => {
       const adapters = getAdapters(getQQBotRuntime());

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -311,7 +311,7 @@ declare module "openclaw/plugin-sdk" {
    * 频道插件 Outbound 接口
    */
   export interface ChannelPluginOutbound {
-    deliveryMode?: "direct" | "queued";
+    deliveryMode?: "direct" | "gateway" | "hybrid";
     chunker?: (text: string, limit: number) => string[];
     chunkerMode?: "markdown" | "plain";
     textChunkLimit?: number;

--- a/src/outbound/errors.ts
+++ b/src/outbound/errors.ts
@@ -5,8 +5,8 @@
  */
 export function botNotRunningMessage(accountId: string): string {
   return (
-    `Bot "${accountId}" has no live connection in this process. ` +
-    `The WebSocket is owned by the OpenClaw gateway; send from that process ` +
-    `(or via \`openclaw gateway call send\`).`
+    `Bot "${accountId}" has no live QQ connection in this process. ` +
+    `The WebSocket is owned by the OpenClaw gateway — ensure the gateway is running ` +
+    `and qqbot account "${accountId}" is started (channels status / gateway logs).`
   );
 }

--- a/src/outbound/errors.ts
+++ b/src/outbound/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Live `QQBotGateway` instances are registered only in the OpenClaw gateway
+ * process. A CLI or other helper process has an empty `gateways` map even
+ * when the bot is connected.
+ */
+export function botNotRunningMessage(accountId: string): string {
+  return (
+    `Bot "${accountId}" has no live connection in this process. ` +
+    `The WebSocket is owned by the OpenClaw gateway; send from that process ` +
+    `(or via \`openclaw gateway call send\`).`
+  );
+}

--- a/src/outbound/media-send.ts
+++ b/src/outbound/media-send.ts
@@ -21,6 +21,7 @@ import { getAdapters } from '../adapter/resolve.js';
 import type { PluginLogger } from '../utils/plugin-logger.js';
 import { validateRemoteUrl } from '../utils/ssrf-guard.js';
 import { getGateway } from './outbound-service.js';
+import { botNotRunningMessage } from './errors.js';
 import { parseTarget } from './target.js';
 import {
   isLocalFilePath,
@@ -158,7 +159,7 @@ export async function sendMedia(params: SendMediaParams): Promise<SendMediaResul
   // 3. 获取 gateway
   const gw = getGateway(accountId);
   if (!gw) {
-    return { error: `Bot "${accountId}" not running` };
+    return { error: botNotRunningMessage(accountId) };
   }
 
   const target = parseTarget(params.to);

--- a/src/outbound/outbound-service.ts
+++ b/src/outbound/outbound-service.ts
@@ -10,6 +10,7 @@ import type { QQBotGateway } from '../gateway/index.js';
 import type { ResolvedQQBotAccount } from '../types.js';
 import { parseTarget } from './target.js';
 import { ReplyLimiter } from './reply-limiter.js';
+import { botNotRunningMessage } from './errors.js';
 
 // ── Gateway + Limiter 注册表（生命周期由 channel.ts 管理）──
 
@@ -80,7 +81,7 @@ export async function sendText(params: {
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
   const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  if (!gw) return { error: botNotRunningMessage(accountId) };
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);
@@ -100,7 +101,7 @@ export async function sendMedia(params: {
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
   const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  if (!gw) return { error: botNotRunningMessage(accountId) };
   try {
     const target = parseTarget(params.to);
     const kind = params.mediaKind ?? 'image';
@@ -133,7 +134,7 @@ export async function sendVoice(params: {
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
   const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  if (!gw) return { error: botNotRunningMessage(accountId) };
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);
@@ -151,7 +152,7 @@ export async function sendVideo(params: {
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
   const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  if (!gw) return { error: botNotRunningMessage(accountId) };
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);


### PR DESCRIPTION
## Summary

`openclaw message send --channel qqbot` fails with `Bot "default" not running` while the gateway bot is connected. This plugin currently declares `outbound.deliveryMode: "direct"`, so OpenClaw core (`sendMessage()` in 2026.8.1, `src/infra/outbound/message.ts:355/393`) runs the send **in the CLI process**. That process has an empty `gateways` map; the live WebSocket is in the gateway process.

OpenClaw already has the correct escape hatch: `deliveryMode: "gateway"` makes CLI send RPC via `callMessageGateway`. The official WeCom plugin uses that mode and does not have this failure.

This PR only changes the declared mode (and the leftover in-process error text). It does **not** start a second bot/WebSocket from the CLI. A second connection is unsafe on platforms that allow only one live session, and is unnecessary here.

Fixes #298 (problem 2). Problem 1 (`outLog.debug is not a function`) is already addressed in current `createOutLog`. Problem 3 (packaging) is out of scope.

## Changes

- `src/channel.ts`: `deliveryMode: "gateway"`
- `src/openclaw-plugin-sdk.d.ts`: host snapshot updated from `"direct" | "queued"` to OpenClaw 2026.8.1 `"direct" | "gateway" | "hybrid"`
- In-process `Bot not running` errors now say the connection lives in the gateway process, instead of implying the bot is down
- Changelog (EN/ZH) under `[Unreleased]`

## How to verify

With OpenClaw gateway running and this plugin loaded:

```bash
openclaw message send --channel qqbot --target "qqbot:c2c:<openid>" --message "ping"
```

Expected: the CLI request is forwarded to the gateway and delivered. Today (2.0.1, `direct`) this returns `Bot "default" not running`.

Gateway-owned inbound replies should be unchanged: core sets `gatewayOwnedDelivery` when already inside the gateway, so the adapter still sends in-process there.

## Out of scope

- Do not construct a CLI-local `QQBotGateway` as a fallback
- Do not change file-upload / COS paths

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - QQ Bot outbound messages now route through the active gateway connection for more reliable delivery.
  - Added support for gateway and hybrid outbound delivery modes.

- **Bug Fixes**
  - Improved “bot not running” errors with clearer guidance when an active gateway connection is required.
  - Standardized error messaging across text, media, voice, and video delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->