### PR TITLE
feat(qqbot): add send-only gateway fallback for outbound sends

### DIFF
--- a/scripts/send-proactive.ts
+++ b/scripts/send-proactive.ts
@@ -24,7 +24,7 @@ import {
   listKnownUsers, 
   getKnownUsersStats,
   broadcastMessage,
-} from "../src/proactive.js";
+} from "../src/features/proactive.js";
 import type { ResolvedQQBotAccount } from "../src/types.js";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -27,7 +27,7 @@ import { getQQBotRuntime, tryGetQQBotRuntime } from './runtime.js';
 import { getAdapters } from './adapter/resolve.js';
 import { sendText, getGateway } from './outbound/outbound-service.js';
 import { sendMedia } from './outbound/media-send.js';
-import type { PluginLogger } from './utils/plugin-logger.js';
+import { createPluginLogger, type PluginLogger } from './utils/plugin-logger.js';
 import { qqbotSetupWizard } from './setup/surface.js';
 import { qqbotLogin, startQrLogin, waitQrLogin } from './setup/login.js';
 import { normalizeTarget, isQQBotTarget } from './outbound/target.js';
@@ -340,7 +340,8 @@ function resolveMCPAgentId(to: string, accountId: string, cfg: unknown, log?: Pl
 
 function createOutLog(accountId: string): PluginLogger {
   const gwLog = getGateway(accountId)?.log;
-  return gwLog?.child('outbound') ?? ({} as PluginLogger);
+  if (gwLog) return gwLog.child('outbound');
+  return createPluginLogger({ forceConsole: true, prefix: `[${accountId}]` }).child('outbound');
 }
 
 // Re-export for backward compatibility

--- a/src/gateway/qqbot-gateway.ts
+++ b/src/gateway/qqbot-gateway.ts
@@ -60,33 +60,51 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   ]);
 }
 
+/** QQBot 公共构造参数（两种模式共享） */
+function baseBotOptions(account: ResolvedQQBotAccount, log: PluginLogger) {
+  return {
+    appId: account.appId,
+    appSecret: account.clientSecret,
+    accountId: account.accountId,
+    markdownSupport: account.markdownSupport,
+    userAgent: buildUserAgent(account.userAgentSuffix),
+    baseUrl: process.env.QQBOT_BASE_URL?.replace(/\/+$/, '') || 'https://api.sgroup.qq.com',
+    tokenBaseUrl: process.env.QQBOT_TOKEN_BASE_URL?.replace(/\/+$/, '') || 'https://bots.qq.com',
+    logger: log,
+  };
+}
+
 export class QQBotGateway {
   readonly bot: QQBot;
   private readonly account: ResolvedQQBotAccount;
-  private readonly runtime: PluginRuntime;
+  private readonly runtime: PluginRuntime | undefined;
   readonly log: PluginLogger;
   private readonly textTimeout: number;
   private readonly mediaTimeout: number;
 
-  constructor(account: ResolvedQQBotAccount, runtime: PluginRuntime, log?: PluginLogger) {
+  /** 完整模式：接收 + 发送（含中间件、session 持久化、ref-index） */
+  constructor(account: ResolvedQQBotAccount, runtime: PluginRuntime, log?: PluginLogger);
+  /** Send-only 模式：仅发送（无中间件、无 session、无 ref-index） */
+  constructor(account: ResolvedQQBotAccount);
+  constructor(account: ResolvedQQBotAccount, runtime?: PluginRuntime, log?: PluginLogger) {
     this.textTimeout = resolveMs('OPENCLAW_OUTBOUND_TIMEOUT_MS', TEXT_TIMEOUT_MS);
     this.mediaTimeout = resolveMs('OPENCLAW_OUTBOUND_MEDIA_TIMEOUT_MS', MEDIA_TIMEOUT_MS);
     this.account = account;
     this.runtime = runtime;
     this.log = log ?? createPluginLogger({ prefix: `[qqbot:${account.accountId}]` });
 
-    const dataDir = getQQBotDataDir(account.accountId);
+    if (!runtime) {
+      // Send-only：极简 QQBot 实例，仅 HTTP REST 发送
+      this.bot = new QQBot({ ...baseBotOptions(account, this.log), tokenPrefetch: 'async' });
+      return;
+    }
 
+    // 完整模式：含 session 持久化、中间件、ref-index
+    const dataDir = getQQBotDataDir(account.accountId);
     const isWebhook = account.config.transport === 'webhook';
 
     this.bot = new QQBot({
-      appId: account.appId,
-      appSecret: account.clientSecret,
-      accountId: account.accountId,
-      markdownSupport: account.markdownSupport,
-      userAgent: buildUserAgent(account.userAgentSuffix),
-      baseUrl: process.env.QQBOT_BASE_URL?.replace(/\/+$/, '') || 'https://api.sgroup.qq.com',
-      tokenBaseUrl: process.env.QQBOT_TOKEN_BASE_URL?.replace(/\/+$/, '') || 'https://bots.qq.com',
+      ...baseBotOptions(account, this.log),
       transport: account.config.transport,
       webhook: isWebhook ? { path: account.config.webhook?.path, server: createPluginWebhookAdapter({ account, log: this.log }) } : undefined,
       sessionPersistence: kvSessionPersistence({
@@ -94,21 +112,21 @@ export class QQBotGateway {
         accountId: account.accountId,
       }),
       tokenPrefetch: 'sync',
-      logger: this.log,
     });
 
-    // 包装 sendText/sendMedia，回复后自动写入 ref-index store
     this.wrapBotSendForRefIndex();
 
-    // concurrencyGuard 的 merge 策略合并后会继续走完剩余中间件链，
-    // 最终与单条消息一样统一由下方 bot.on('message') 处理转发，
-    // 因此这里不再需要单独的 onMergeDispatch 回调。
     setupMiddlewares(this.bot, account, {
       getRuntime: () => runtime,
     });
   }
 
   async start(callbacks?: GatewayCallbacks, signal?: AbortSignal): Promise<void> {
+    if (!this.runtime) {
+      throw new Error(`[qqbot] Cannot start send-only gateway "${this.account.accountId}"`);
+    }
+    const runtime = this.runtime;
+
     const handleReady = () => {
       this.log.info(`Gateway ready`);
       callbacks?.onReady?.();
@@ -127,14 +145,14 @@ export class QQBotGateway {
     this.bot.on('message', async (ctx: MiddlewareContext, msg: QQBotInboundMessage) => {
       gatewayLog.debug(`message msgId=${msg.messageId}`);
       try {
-        await handleMessage(ctx, msg, this.account, this.runtime, this.log);
+        await handleMessage(ctx, msg, this.account, runtime, this.log);
       } catch (err) {
         gatewayLog.error(`Dispatch error: ${err instanceof Error ? err.message : String(err)}`);
       }
     });
 
     this.bot.on('interaction', (_ctx, event: InteractionEvent) => {
-      handleInteraction(event, this.account, this.runtime, this.log, (id, code, data) =>
+      handleInteraction(event, this.account, runtime, this.log, (id, code, data) =>
         this.bot.acknowledgeInteraction(id, code, data),
       ).catch((err) => {
         this.log.error(`Interaction error: ${err}`);

--- a/src/outbound/outbound-service.ts
+++ b/src/outbound/outbound-service.ts
@@ -6,7 +6,7 @@
  */
 import * as path from 'node:path';
 import { MediaFileType } from '@tencent-connect/qqbot-nodejs';
-import type { QQBotGateway } from '../gateway/index.js';
+import { QQBotGateway } from '../gateway/index.js';
 import type { ResolvedQQBotAccount } from '../types.js';
 import { parseTarget } from './target.js';
 import { ReplyLimiter } from './reply-limiter.js';
@@ -51,6 +51,16 @@ export function getGateway(accountId: string): QQBotGateway | undefined {
   return gateways.get(accountId);
 }
 
+/** gateway 未运行时，惰性构造 send-only 实例并注册进 Map 缓存复用 */
+function getOrCreateGateway(account: ResolvedQQBotAccount): QQBotGateway {
+  let gw = gateways.get(account.accountId);
+  if (!gw) {
+    gw = new QQBotGateway(account);
+    gateways.set(account.accountId, gw);
+  }
+  return gw;
+}
+
 // ── 媒体类型映射 ──
 
 export type MediaKind = 'image' | 'voice' | 'video' | 'file';
@@ -79,8 +89,7 @@ export async function sendText(params: {
   account: ResolvedQQBotAccount;
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
-  const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  const gw = getOrCreateGateway(params.account);
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);
@@ -99,8 +108,7 @@ export async function sendMedia(params: {
   account: ResolvedQQBotAccount;
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
-  const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  const gw = getOrCreateGateway(params.account);
   try {
     const target = parseTarget(params.to);
     const kind = params.mediaKind ?? 'image';
@@ -132,8 +140,7 @@ export async function sendVoice(params: {
   account: ResolvedQQBotAccount;
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
-  const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  const gw = getOrCreateGateway(params.account);
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);
@@ -150,8 +157,7 @@ export async function sendVideo(params: {
   account: ResolvedQQBotAccount;
 }): Promise<SendResult> {
   const accountId = params.account.accountId;
-  const gw = gateways.get(accountId);
-  if (!gw) return { error: `Bot "${accountId}" not running` };
+  const gw = getOrCreateGateway(params.account);
   try {
     const target = parseTarget(params.to);
     const msgId = resolveMsgId(params.replyToId, accountId);


### PR DESCRIPTION
## What Problem This Solves

When the QQBot gateway is not running (for example, scheduled tasks, MCP-tool
triggered outbound, or a stopped gateway), the outbound helpers `sendText`,
`sendMedia`, `sendVoice`, and `sendVideo` return `Bot "<accountId>" not running`,
so messages cannot be sent in those scenarios. Outbound sending previously
depended on a fully started gateway instance and had no way to send
independently of the gateway's running state.

## Why This Change Was Made

`QQBotGateway` now has an overloaded constructor with a **send-only mode**: when
`runtime` is omitted, it builds a minimal QQBot instance (HTTP REST send only)
with no middleware, session persistence, or ref-index; when `runtime` is
provided, it keeps the existing full mode (receive + send). Both modes share a
new `baseBotOptions` helper for the common constructor options.

`outbound-service` adds `getOrCreateGateway`, which lazily constructs a
send-only instance when the gateway is not running, caches it in the Map for
reuse, and routes `sendText` / `sendMedia` / `sendVoice` / `sendVideo` through
it so they no longer fail with "not running".

`createOutLog` also falls back to a real logger (`createPluginLogger`) when no
gateway log exists, instead of returning an empty object, and `start()` throws a
clear error for send-only instances to prevent starting an instance that cannot
receive.

## User Impact

- Outbound sending no longer depends on the gateway's running state.
- Scheduled tasks and MCP tools can send messages without middleware or session
  contexts.
- Fixes missing outbound logs when no gateway log exists.

## Evidence

- Changed files: `src/channel.ts`, `src/gateway/qqbot-gateway.ts`,
  `src/outbound/outbound-service.ts` (+53 / -28).

<img width="1059" height="213" alt="image" src="https://github.com/user-attachments/assets/a8d4403c-f502-4e46-a893-58d4664f33c5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added send-only mode for QQ Bot accounts, enabling outbound messages without starting a receive connection.
  * Outbound text, media, voice, and video messages can now automatically create the required gateway when one is not already active.

* **Bug Fixes**
  * Improved fallback logging so diagnostic messages remain visible when gateway logging is unavailable.
  * Corrected proactive messaging support to use the appropriate module path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->