### PR TITLE
docs: remove Star History chart from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,10 +685,3 @@ Thanks to [Tencent Cloud Lighthouse](https://cloud.tencent.com/product/lighthous
   <img alt="Tencent Cloud Lighthouse" src="./docs/images/lighthouse-head.png" height="500" style="max-width:80%; height:auto;"/>
 </a>
 
-## ⭐ Star History
-
-<div align="center">
-
-[![Star History Chart](https://api.star-history.com/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://www.star-history.com/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
-
-</div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -682,10 +682,3 @@ STT 支持两级配置，按优先级查找：
   <img alt="腾讯云 Lighthouse" src="./docs/images/lighthouse-head.png" height="500" style="max-width:80%; height:auto;"/>
 </a>
 
-## ⭐ Star History
-
-<div align="center">
-
-[![Star History Chart](https://api.star-history.com/svg?repos=tencent-connect/openclaw-qqbot&type=date&legend=top-left)](https://www.star-history.com/#tencent-connect/openclaw-qqbot&type=date&legend=top-left)
-
-</div>


### PR DESCRIPTION
## What Problem This Solves

The README (and its Chinese counterpart `README.zh.md`) included a "Star
History" section embedding a chart served by the third-party `star-history.com`
service. This section is removed so the project documentation no longer depends
on the external chart service rendering correctly.

## Why This Change Was Made

Remove the `## ⭐ Star History` section and its embedded `api.star-history.com`
chart image from both `README.md` and `README.zh.md`. The removal drops the
external service dependency from the documentation and shortens the README.

## User Impact

No functional change. The README is slightly shorter and no longer loads the
external star-history chart image.

## Evidence

- `README.md`: removed the Star History section (7 lines).
- `README.zh.md`: removed the Star History section (7 lines).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the Star History chart and related link from the English README.
  - Removed the corresponding Star History section from the Chinese README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->