### PR TITLE
fix(approval): disable handler when approvals factory is missing

### DIFF
--- a/src/adapter/gateway.ts
+++ b/src/adapter/gateway.ts
@@ -13,10 +13,27 @@ export interface ApprovalGatewayClient {
   request: (method: string, params: unknown) => Promise<unknown>;
 }
 
-/** 动态加载 gateway-runtime 模块，旧版框架不可用时返回 null */
-export function loadApprovalGatewayRuntime(): {
+type ApprovalGatewayRuntime = {
   createOperatorApprovalsGatewayClient: (...args: any[]) => Promise<ApprovalGatewayClient>;
-} | null {
+};
+
+/** Accept only modules that actually export the approvals factory (stale ESM builds often don't). */
+export function asApprovalGatewayRuntime(mod: unknown): ApprovalGatewayRuntime | null {
+  if (!mod || typeof mod !== "object") return null;
+  const record = mod as Record<string, unknown>;
+  const nested = record.default;
+  const candidates = [record, nested && typeof nested === "object" ? (nested as Record<string, unknown>) : null];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (typeof candidate.createOperatorApprovalsGatewayClient === "function") {
+      return candidate as ApprovalGatewayRuntime;
+    }
+  }
+  return null;
+}
+
+/** 动态加载 gateway-runtime 模块，旧版框架或缺少 factory 时返回 null */
+export function loadApprovalGatewayRuntime(): ApprovalGatewayRuntime | null {
   const req = createRequire(__filename);
   const pluginRoot = path.resolve(path.dirname(__filename), '..', '..');
   const fs = req('node:fs') as typeof import('node:fs');
@@ -25,7 +42,10 @@ export function loadApprovalGatewayRuntime(): {
     for (const rel of ['dist/plugin-sdk/gateway-runtime.js', 'plugin-sdk/gateway-runtime.js']) {
       const p = path.join(root, rel);
       try {
-        if (fs.existsSync(p)) return req(p);
+        if (fs.existsSync(p)) {
+          const runtime = asApprovalGatewayRuntime(req(p));
+          if (runtime) return runtime;
+        }
       } catch { /* try next */ }
     }
     return null;

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -12,4 +12,4 @@
 
 export { verifyRuntimeContract, type ContractResult } from './contract.js';
 export { resolveRuntimeAdapters, getAdapters, type RuntimeAdapters } from './resolve.js';
-export { loadApprovalGatewayRuntime, type ApprovalGatewayClient } from './gateway.js';
+export { loadApprovalGatewayRuntime, asApprovalGatewayRuntime, type ApprovalGatewayClient } from './gateway.js';

--- a/tests/gateway-runtime-export.test.ts
+++ b/tests/gateway-runtime-export.test.ts
@@ -1,0 +1,52 @@
+/**
+ * gateway-runtime 导出探测：缺少 createOperatorApprovalsGatewayClient 时必须降级，
+ * 不能把半截 ESM 模块当成可用 runtime（否则每 30s TypeError）。
+ *
+ * 运行：npx tsx tests/gateway-runtime-export.test.ts
+ */
+import assert from "node:assert";
+import { asApprovalGatewayRuntime } from "../src/adapter/gateway.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+  } catch (err) {
+    failed++;
+    console.error(`FAIL ${name}: ${err}`);
+  }
+}
+
+test("null / non-object → null", () => {
+  assert.equal(asApprovalGatewayRuntime(null), null);
+  assert.equal(asApprovalGatewayRuntime(undefined), null);
+  assert.equal(asApprovalGatewayRuntime("nope"), null);
+});
+
+test("loaded module without factory → null (stale plugin-sdk)", () => {
+  assert.equal(
+    asApprovalGatewayRuntime({ GatewayClient: class {}, startGatewayClientWhenEventLoopReady: () => {} }),
+    null,
+  );
+});
+
+test("named export factory → runtime", () => {
+  const fn = async () => ({ start() {}, stop() {}, request: async () => null });
+  const runtime = asApprovalGatewayRuntime({ createOperatorApprovalsGatewayClient: fn });
+  assert.ok(runtime);
+  assert.equal(runtime.createOperatorApprovalsGatewayClient, fn);
+});
+
+test("default export factory (CJS interop) → runtime", () => {
+  const fn = async () => ({ start() {}, stop() {}, request: async () => null });
+  const runtime = asApprovalGatewayRuntime({ default: { createOperatorApprovalsGatewayClient: fn } });
+  assert.ok(runtime);
+  assert.equal(runtime.createOperatorApprovalsGatewayClient, fn);
+});
+
+console.log(`passed=${passed} failed=${failed}`);
+if (failed) process.exit(1);
+console.log("OK");


### PR DESCRIPTION
## Summary
OpenClaw source already re-exports `createOperatorApprovalsGatewayClient` for this plugin, but a stale `dist/plugin-sdk/gateway-runtime.js` (or CJS `require()` of an ESM build) can still load without that function.

Today the approval handler treats any loaded module as usable and then throws:

`TypeError: gatewayRuntime.createOperatorApprovalsGatewayClient is not a function`

on every approval poll. Message delivery keeps working; the log just fills with errors.

This change:
- treats a module without the factory as **unavailable** (same as old OpenClaw)
- also accepts `default.createOperatorApprovalsGatewayClient` for CJS interop
- adds a small node test for the probe

## Test plan
- [x] `npx tsx tests/gateway-runtime-export.test.ts`
- [ ] CI / maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime loading validation to reject invalid or outdated modules.
  * Added support for both named and default runtime exports.
  * Prevented failures when expected runtime functionality is missing.

* **Tests**
  * Added coverage for invalid inputs, outdated modules, and supported export formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->