### PR TITLE
feat: add MiniMax TTS to QQ voice replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,45 @@ STT supports two-level configuration with priority fallback:
 - Set `enabled: false` to disable (default: `true`)
 - When configured, AI can generate and send voice messages
 
+MiniMax speech is used as a fallback when the OpenClaw runtime does not expose
+its own TTS provider. The QQBot plugin discovers a configured speech model and
+uses either the global or mainland China endpoint selected by `region`:
+
+```json
+{
+  "channels": {
+    "qqbot": {
+      "tts": {
+        "provider": "minimax-speech",
+        "region": "global_en",
+        "voice": "your-voice-id",
+        "outputFormat": "wav"
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "minimax-speech": {
+        "apiKey": "${MINIMAX_API_KEY}",
+        "models": [{ "id": "speech-2.8-hd" }],
+        "endpoints": [
+          { "region": "global_en", "url": "https://api.minimax.io/v1/t2a_v2" },
+          { "region": "cn_zh", "url": "https://api.minimaxi.com/v1/t2a_v2" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Supported speech models are discovered from the provider configuration. The
+current model family includes `speech-2.8-hd`, `speech-2.8-turbo`,
+`speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`, `speech-02-turbo`,
+`speech-01-hd`, and `speech-01-turbo`. Audio output can be `mp3`, `wav`,
+`flac`, or `pcm`. Optional request settings include `voiceSetting`,
+`audioSetting`, `languageBoost`, `pronunciationDict`, `voiceModify`, and
+`subtitleEnable`.
+
 ---
 
 ## 📚 Documentation & Links
@@ -684,4 +723,3 @@ Thanks to [Tencent Cloud Lighthouse](https://cloud.tencent.com/product/lighthous
 <a href="https://cloud.tencent.com/product/lighthouse">
   <img alt="Tencent Cloud Lighthouse" src="./docs/images/lighthouse-head.png" height="500" style="max-width:80%; height:auto;"/>
 </a>
-

--- a/src/dispatch/dispatch.ts
+++ b/src/dispatch/dispatch.ts
@@ -24,6 +24,7 @@ import { DeliverDebouncer } from '../outbound/debounce.js';
 import { StreamingController, shouldUseStreaming } from '../outbound/streaming-controller.js';
 import { getAdapters } from '../adapter/resolve.js';
 import { clearGroupHistory } from '../features/history-store.js';
+import { resolveTTSProvider } from '../outbound/tts-provider.js';
 
 
 /**
@@ -69,7 +70,8 @@ export async function dispatchToOpenClaw(
 
   const ctxPayload = buildCtxPayload({ assembled, envelope, route, msg, ctx, adapters });
 
-  const ttsRuntime = (runtime as any)?.tts ?? (runtime as any)?.channel?.runtimeContexts?.get?.('tts');
+  const ttsRuntime = (runtime as any)?.tts ?? (runtime as any)?.channel?.runtimeContexts?.get?.('tts'); // @adapter-bypass: TTS is not part of the channel adapter API
+  const ttsProvider = resolveTTSProvider(runtime, cfg);
 
   const debounceConfig = account.config?.deliverDebounce;
   const debouncer = debounceConfig?.enabled !== false
@@ -90,6 +92,7 @@ export async function dispatchToOpenClaw(
       to,
       source,
       text: opts?.text ?? '',
+      mediaKind: opts?.mediaKind,
       replyToId: envelope.messageId,
       accountId: account.accountId,
       agentId: route.agentId,
@@ -97,7 +100,15 @@ export async function dispatchToOpenClaw(
     }),
     textToSpeech: ttsRuntime?.textToSpeech
       ? (params) => ttsRuntime.textToSpeech(params)
-      : undefined,
+      : ttsProvider
+        ? async (params) => {
+            try {
+              return { audioPath: await ttsProvider.textToSpeech(params) };
+            } catch (error) {
+              return { audioPath: null, error: error instanceof Error ? error.message : String(error) };
+            }
+          }
+        : undefined,
     audioFileToSilkBase64: ttsRuntime?.audioFileToSilkBase64
       ? (audioPath: string) => ttsRuntime.audioFileToSilkBase64(audioPath)
       : undefined,

--- a/src/outbound/tts-provider.ts
+++ b/src/outbound/tts-provider.ts
@@ -1,22 +1,198 @@
 /**
- * TTS（文字转语音）集成接口
+ * TTS integration for the runtime-to-QQ voice pipeline.
  *
- * audioAsVoice 语音回复能力：
- *   text → TTS → audioPath → SILK 转换 → Base64 → sendVoice
- *
- * 本模块定义接口和桥接逻辑。实际 TTS 引擎由 openclaw 框架的
- * tts-runtime 插件提供（通过 runtime 注入），本文件不内置 TTS 实现。
+ * The runtime provider remains the preferred integration. When the runtime
+ * does not expose one, MiniMax can be resolved from the OpenClaw model config
+ * and used without changing the existing deliver pipeline.
  */
-import { convertSilkToWav } from '@tencent-connect/qqbot-nodejs/protocol';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 /**
  * TTS Provider 接口（由框架注入或用户自定义）
  */
 export interface TTSProvider {
-  /** 文字转语音 → 返回本地音频文件路径（wav/mp3 等） */
+  /** Convert text to speech and return a local audio path. */
   textToSpeech(params: { text: string; cfg?: unknown; channel?: string; accountId?: string }): Promise<string | null>;
-  /** 音频文件 → SILK Base64（用于 QQ 发送） */
+  /** Convert an audio file to SILK Base64 for QQ, when the runtime supplies it. */
   audioFileToSilkBase64?(audioPath: string): Promise<string | null>;
+}
+
+const MINIMAX_SPEECH_MODELS = [
+  'speech-2.8-hd',
+  'speech-2.8-turbo',
+  'speech-2.6-hd',
+  'speech-2.6-turbo',
+  'speech-02-hd',
+  'speech-02-turbo',
+  'speech-01-hd',
+  'speech-01-turbo',
+] as const;
+
+const AUDIO_FORMATS = new Set(['mp3', 'wav', 'flac', 'pcm']);
+const MINIMAX_SPEECH_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/t2a_v2',
+  cn_zh: 'https://api.minimaxi.com/v1/t2a_v2',
+} as const;
+
+export interface MiniMaxTTSConfig {
+  apiKey: string;
+  endpoint: string;
+  model: string;
+  outputFormat: 'mp3' | 'wav' | 'flac' | 'pcm';
+  voiceSetting?: Record<string, unknown>;
+  audioSetting?: Record<string, unknown>;
+  languageBoost?: unknown;
+  pronunciationDict?: unknown;
+  voiceModify?: unknown;
+  subtitleEnable?: boolean;
+  timeoutMs: number;
+}
+
+/** Resolve the MiniMax provider, model, and regional endpoint from runtime config. */
+export function resolveMiniMaxTTSConfig(cfg: unknown): MiniMaxTTSConfig | null {
+  const root = asRecord(cfg);
+  if (!root) return null;
+
+  const channels = asRecord(root.channels);
+  const qqbot = asRecord(channels?.qqbot);
+  const channelTts = asRecord(qqbot?.tts);
+  if (channelTts?.enabled === false) return null;
+
+  const messages = asRecord(root.messages);
+  const messageTts = asRecord(messages?.tts);
+  const tts = channelTts ?? messageTts;
+  if (tts?.enabled === false) return null;
+
+  const models = asRecord(root.models);
+  const providers = asRecord(models?.providers);
+  const requestedProvider = readString(tts, 'provider');
+  const providerId = requestedProvider ?? findMiniMaxProvider(providers);
+  const provider = providerId ? asRecord(providers?.[providerId]) : undefined;
+
+  const providerLooksLikeMiniMax = /minimax/i.test([
+    providerId,
+    readString(provider, 'name'),
+    readString(provider, 'baseUrl'),
+    readString(tts, 'endpoint'),
+    readString(tts, 'baseUrl'),
+  ].filter(Boolean).join(' '));
+  if (!providerLooksLikeMiniMax) return null;
+
+  const endpoint = resolveEndpoint(tts, provider);
+  const apiKey = readString(tts, 'apiKey') ?? readString(provider, 'apiKey');
+  if (!apiKey || !endpoint) return null;
+
+  const model = readString(tts, 'model')
+    ?? findConfiguredSpeechModel(provider)
+    ?? MINIMAX_SPEECH_MODELS[0];
+  const outputFormat = resolveOutputFormat(tts, provider);
+  const voiceSetting = resolveObject(tts, 'voiceSetting')
+    ?? resolveObject(provider, 'voiceSetting')
+    ?? (readString(tts, 'voice') ? { voice_id: readString(tts, 'voice') } : undefined);
+  const audioSetting = {
+    ...(resolveObject(provider, 'audioSetting') ?? {}),
+    ...(resolveObject(tts, 'audioSetting') ?? {}),
+    format: outputFormat,
+  };
+
+  return {
+    apiKey,
+    endpoint,
+    model,
+    outputFormat,
+    voiceSetting,
+    audioSetting,
+    languageBoost: tts?.languageBoost ?? provider?.languageBoost,
+    pronunciationDict: tts?.pronunciationDict ?? provider?.pronunciationDict,
+    voiceModify: tts?.voiceModify ?? provider?.voiceModify,
+    subtitleEnable: readBoolean(tts, 'subtitleEnable') ?? readBoolean(provider, 'subtitleEnable'),
+    timeoutMs: readNumber(tts, 'timeoutMs') ?? 30_000,
+  };
+}
+
+/** Build the documented MiniMax HTTP request body. */
+export function buildMiniMaxTTSRequest(config: MiniMaxTTSConfig, text: string): Record<string, unknown> {
+  const request: Record<string, unknown> = {
+    model: config.model,
+    text,
+    stream: false,
+    output_format: 'hex',
+    audio_setting: config.audioSetting,
+  };
+  if (config.voiceSetting) request.voice_setting = config.voiceSetting;
+  if (config.languageBoost !== undefined) request.language_boost = config.languageBoost;
+  if (config.pronunciationDict !== undefined) request.pronunciation_dict = config.pronunciationDict;
+  if (config.voiceModify !== undefined) request.voice_modify = config.voiceModify;
+  if (config.subtitleEnable !== undefined) request.subtitle_enable = config.subtitleEnable;
+  return request;
+}
+
+/** Parse a synchronous or streamed MiniMax response and combine audio chunks. */
+export function parseMiniMaxTTSResponse(payload: unknown): { audio: string; status?: number } {
+  const entries = Array.isArray(payload) ? payload : [payload];
+  let status: number | undefined;
+  const chunks: string[] = [];
+  for (const entry of entries) {
+    const object = asRecord(entry);
+    const baseResponse = asRecord(object?.base_resp);
+    const statusCode = baseResponse?.status_code;
+    if (statusCode !== undefined && Number(statusCode) !== 0) {
+      const message = readString(baseResponse, 'status_msg') ?? 'MiniMax TTS request failed';
+      throw new Error(message);
+    }
+    const data = asRecord(object?.data);
+    const currentStatus = data?.status;
+    if (typeof currentStatus === 'number') status = currentStatus;
+    const audio = data?.audio;
+    if (typeof audio === 'string' && audio.trim()) chunks.push(audio.trim());
+  }
+  if (chunks.length === 0) throw new Error('MiniMax TTS returned no audio');
+  return { audio: chunks.join(''), status };
+}
+
+/** Create a MiniMax provider using the current OpenClaw runtime configuration. */
+export function createMiniMaxTTSProvider(
+  cfg: unknown,
+  options: { fetch?: typeof fetch } = {},
+): TTSProvider | undefined {
+  const config = resolveMiniMaxTTSConfig(cfg);
+  if (!config) return undefined;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') return undefined;
+
+  return {
+    textToSpeech: async ({ text }) => {
+      if (!text.trim()) return null;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+      try {
+        const response = await fetchImpl(config.endpoint, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(buildMiniMaxTTSRequest(config, text)),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const detail = await response.text().catch(() => '');
+          throw new Error(`MiniMax TTS failed (HTTP ${response.status}): ${detail.slice(0, 300)}`);
+        }
+        const parsed = parseMiniMaxTTSResponse(await response.json());
+        const bytes = decodeAudio(parsed.audio);
+        const extension = config.outputFormat === 'pcm' ? 'pcm' : config.outputFormat;
+        const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-qqbot-tts-'));
+        const audioPath = path.join(directory, `speech.${extension}`);
+        await fs.writeFile(audioPath, bytes);
+        return audioPath;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
 }
 
 /**
@@ -25,7 +201,7 @@ export interface TTSProvider {
  * openclaw 框架通过 `runtime.channel.runtimeContexts` 或直接挂载 `runtime.tts`
  * 提供 TTS 能力。本函数做兼容性探测。
  */
-export function resolveTTSProvider(runtime: any): TTSProvider | undefined {
+export function resolveTTSProvider(runtime: any, cfg?: unknown): TTSProvider | undefined {
   // 方式 1: runtime.tts (直接挂载)
   if (runtime?.tts?.textToSpeech) {
     return runtime.tts;
@@ -35,7 +211,7 @@ export function resolveTTSProvider(runtime: any): TTSProvider | undefined {
   if (tts?.textToSpeech) {
     return tts;
   }
-  return undefined;
+  return createMiniMaxTTSProvider(cfg);
 }
 
 /**
@@ -81,4 +257,99 @@ export async function textToVoiceBase64(
   });
   if (!audioPath) return null;
   return audioToSilkBase64(audioPath, provider);
+}
+
+function asRecord(value: unknown): Record<string, any> | undefined {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, any>;
+  return undefined;
+}
+
+function readString(object: Record<string, any> | undefined, key: string): string | undefined {
+  const value = object?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readValueString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(object: Record<string, any> | undefined, key: string): number | undefined {
+  const value = object?.[key];
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function readBoolean(object: Record<string, any> | undefined, key: string): boolean | undefined {
+  return typeof object?.[key] === 'boolean' ? object[key] : undefined;
+}
+
+function resolveObject(object: Record<string, any> | undefined, key: string): Record<string, unknown> | undefined {
+  return asRecord(object?.[key]) as Record<string, unknown> | undefined;
+}
+
+function findMiniMaxProvider(providers: Record<string, any> | undefined): string | undefined {
+  if (!providers) return undefined;
+  return Object.keys(providers).find((id) => {
+    const provider = asRecord(providers[id]);
+    return /minimax/i.test(`${id} ${readString(provider, 'name') ?? ''} ${readString(provider, 'baseUrl') ?? ''}`);
+  });
+}
+
+function findConfiguredSpeechModel(provider: Record<string, any> | undefined): string | undefined {
+  const models = provider?.models;
+  if (!Array.isArray(models)) return undefined;
+  for (const model of models) {
+    const id = typeof model === 'string' ? model : readString(asRecord(model), 'id') ?? readString(asRecord(model), 'model');
+    if (id && (MINIMAX_SPEECH_MODELS as readonly string[]).includes(id)) return id;
+  }
+  return undefined;
+}
+
+function resolveEndpoint(tts: Record<string, any> | undefined, provider: Record<string, any> | undefined): string | undefined {
+  const region = readString(tts, 'region') ?? readString(provider, 'region');
+  const configuredEndpoints = tts?.endpoints ?? provider?.endpoints ?? provider?.regionalEndpoints;
+  if (Array.isArray(configuredEndpoints)) {
+    const regional = configuredEndpoints.find((entry) => {
+      const item = asRecord(entry);
+      return !region || readString(item, 'region') === region;
+    });
+    const regionalUrl = readString(asRecord(regional), 'url') ?? readString(asRecord(regional), 'endpoint');
+    if (regionalUrl) return normalizeEndpoint(regionalUrl);
+  } else if (configuredEndpoints && typeof configuredEndpoints === 'object') {
+    const endpoint = readValueString(asRecord(configuredEndpoints)?.[region ?? ''])
+      ?? readValueString(asRecord(configuredEndpoints)?.global_en);
+    if (endpoint) return normalizeEndpoint(endpoint);
+  }
+  return normalizeEndpoint(
+    readString(tts, 'endpoint')
+      ?? readString(tts, 'baseUrl')
+      ?? readString(provider, 'baseUrl')
+      ?? MINIMAX_SPEECH_ENDPOINTS[region === 'cn_zh' ? 'cn_zh' : 'global_en'],
+  );
+}
+
+function normalizeEndpoint(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const endpoint = value.replace(/\/+$/, '');
+  const normalized = /\/t2a_v2$/i.test(endpoint)
+    ? endpoint
+    : /\/v1$/i.test(endpoint)
+      ? `${endpoint}/t2a_v2`
+      : `${endpoint}/v1/t2a_v2`;
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== 'https:' || !['api.minimax.io', 'api.minimaxi.com'].includes(parsed.hostname)) return undefined;
+  } catch {
+    return undefined;
+  }
+  return normalized;
+}
+
+function resolveOutputFormat(tts: Record<string, any> | undefined, provider: Record<string, any> | undefined): MiniMaxTTSConfig['outputFormat'] {
+  const requested = readString(tts, 'outputFormat') ?? readString(tts, 'audioFormat') ?? readString(provider, 'outputFormat');
+  return requested && AUDIO_FORMATS.has(requested) ? requested as MiniMaxTTSConfig['outputFormat'] : 'wav';
+}
+
+function decodeAudio(audio: string): Buffer {
+  if (/^[0-9a-f]+$/i.test(audio) && audio.length % 2 === 0) return Buffer.from(audio, 'hex');
+  return Buffer.from(audio, 'base64');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface QQBotConfig {
   clientSecretFile?: string;
 }
 
+
 /**
  * 解析后的 QQ Bot 账户
  */
@@ -159,6 +160,8 @@ export interface QQBotAccountConfig {
    * 配置后，收到语音消息时会自动调用 STT 服务转录为文字
    */
   stt?: STTChannelConfig;
+  /** TTS provider settings resolved from models.providers. */
+  tts?: TTSChannelConfig;
   /**
    * 单条消息最大处理时间（毫秒）。
    * 超时后 concurrencyGuard 会 abort 处理链（取消 LLM 调用、工具执行等），
@@ -242,6 +245,28 @@ export interface STTChannelConfig {
   apiKey?: string;
   /** STT 模型名称（默认 "whisper-1"） */
   model?: string;
+}
+
+/** TTS provider settings resolved from models.providers. */
+export interface TTSChannelConfig {
+  enabled?: boolean;
+  provider?: string;
+  baseUrl?: string;
+  endpoint?: string;
+  apiKey?: string;
+  model?: string;
+  voice?: string;
+  region?: string;
+  outputFormat?: string;
+  audioFormat?: string;
+  voiceSetting?: Record<string, unknown>;
+  audioSetting?: Record<string, unknown>;
+  languageBoost?: unknown;
+  pronunciationDict?: unknown;
+  voiceModify?: unknown;
+  subtitleEnable?: boolean;
+  timeoutMs?: number;
+  endpoints?: Array<{ region?: string; url?: string; endpoint?: string }> | Record<string, string>;
 }
 
 /**
@@ -540,5 +565,3 @@ export interface StreamMessageRequest {
   /** 同一条流式会话内的发送索引，从 0 开始，每次发送前递增；新流式会话重新从 0 开始 */
   index: number;
 }
-
-

--- a/tests/tts-provider.test.ts
+++ b/tests/tts-provider.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  buildMiniMaxTTSRequest,
+  createMiniMaxTTSProvider,
+  parseMiniMaxTTSResponse,
+  resolveMiniMaxTTSConfig,
+} from '../src/outbound/tts-provider.js';
+
+const config = {
+  channels: {
+    qqbot: {
+      tts: {
+        provider: 'minimax-speech',
+        region: 'cn_zh',
+        voice: 'test-voice',
+        outputFormat: 'flac',
+        languageBoost: 'auto',
+      },
+    },
+  },
+  models: {
+    providers: {
+      'minimax-speech': {
+        apiKey: 'test-key',
+        models: [{ id: 'speech-2.6-turbo' }],
+        endpoints: [
+          { region: 'global_en', url: 'https://api.minimax.io/v1/t2a_v2' },
+          { region: 'cn_zh', url: 'https://api.minimaxi.com/v1/t2a_v2' },
+        ],
+      },
+    },
+  },
+};
+
+const resolved = resolveMiniMaxTTSConfig(config);
+assert.ok(resolved);
+assert.equal(resolved.endpoint, 'https://api.minimaxi.com/v1/t2a_v2');
+assert.equal(resolved.model, 'speech-2.6-turbo');
+assert.equal(resolved.outputFormat, 'flac');
+assert.deepEqual(resolved.voiceSetting, { voice_id: 'test-voice' });
+
+const defaultEndpoint = resolveMiniMaxTTSConfig({
+  channels: { qqbot: { tts: { provider: 'minimax', region: 'global_en' } } },
+  models: { providers: { minimax: { apiKey: 'test-key' } } },
+});
+assert.equal(defaultEndpoint?.endpoint, 'https://api.minimax.io/v1/t2a_v2');
+assert.equal(defaultEndpoint?.model, 'speech-2.8-hd');
+
+assert.equal(resolveMiniMaxTTSConfig({
+  channels: { qqbot: { tts: { provider: 'minimax', endpoint: 'https://example.com/v1/t2a_v2' } } },
+  models: { providers: { minimax: { apiKey: 'test-key' } } },
+}), null);
+
+const request = buildMiniMaxTTSRequest(resolved, 'hello');
+assert.deepEqual(request, {
+  model: 'speech-2.6-turbo',
+  text: 'hello',
+  stream: false,
+  output_format: 'hex',
+  audio_setting: { format: 'flac' },
+  voice_setting: { voice_id: 'test-voice' },
+  language_boost: 'auto',
+});
+
+assert.deepEqual(
+  parseMiniMaxTTSResponse({
+    data: { audio: '52494646', status: 2 },
+    base_resp: { status_code: 0 },
+  }),
+  { audio: '52494646', status: 2 },
+);
+assert.throws(
+  () => parseMiniMaxTTSResponse({ base_resp: { status_code: 1001, status_msg: 'invalid request' } }),
+  /invalid request/,
+);
+
+let capturedUrl = '';
+let capturedBody: Record<string, unknown> | undefined;
+const fakeFetch = async (input: string | URL | Request, init?: RequestInit) => {
+  capturedUrl = String(input);
+  capturedBody = JSON.parse(String(init?.body));
+  return new Response(JSON.stringify({
+    data: { audio: '52494646', status: 2 },
+    base_resp: { status_code: 0 },
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+
+const provider = createMiniMaxTTSProvider(config, { fetch: fakeFetch });
+assert.ok(provider);
+const audioPath = await provider.textToSpeech({ text: 'hello' });
+assert.ok(audioPath);
+assert.equal(capturedUrl, 'https://api.minimaxi.com/v1/t2a_v2');
+assert.equal(capturedBody?.model, 'speech-2.6-turbo');
+assert.deepEqual(await fs.readFile(audioPath), Buffer.from('52494646', 'hex'));
+await fs.rm(path.dirname(audioPath), { recursive: true });
+
+console.log('MiniMax TTS provider tests passed');


### PR DESCRIPTION
Reason: add MiniMax TTS to the runtime-to-QQ voice pipeline with regional endpoint selection and runtime model discovery.

## Summary

- fall back to MiniMax speech when the OpenClaw runtime does not expose a TTS provider
- discover speech configuration from the current runtime, select the global or mainland China endpoint, and forward supported request options
- decode the documented audio response into a safe temporary file and route it through the existing QQ voice sender
- document the configuration and cover endpoint, model, request, response, and file handling with focused tests

## Checks

- `npm run typecheck`
- `npm run build`
- `npx --yes tsx src/adapter/lint.ts`
- `npx --yes tsx tests/tts-provider.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MiniMax speech synthesis as a fallback when no runtime TTS provider is available.
  - Added configuration support for regional endpoints, speech models, output formats, and optional request settings.
  - Added automatic audio generation with clear handling for provider errors.

- **Documentation**
  - Documented MiniMax TTS setup and configuration examples.

- **Tests**
  - Added coverage for regional settings, request construction, response parsing, validation, and audio generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->