### PR TITLE
fix: keep recoverable QQ Bot accounts visible to OpenClaw

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -19,6 +19,7 @@ import {
   resolveQQBotAccount,
   applyQQBotAccountConfig,
   resolveDefaultQQBotAccountId,
+  isQQBotAccountConfigured,
   resolveRequireMention,
   resolveToolPolicy,
   resolveGroupConfig,
@@ -33,7 +34,6 @@ import { qqbotLogin, startQrLogin, waitQrLogin } from './setup/login.js';
 import { normalizeTarget, isQQBotTarget } from './outbound/target.js';
 import { sanitizeQQBotText } from './outbound/sanitize.js';
 import { startAccountWithCredentialRecovery, logoutAndClearCredentials, stopAccountGracefully } from './gateway/lifecycle.js';
-import { loadCredentialBackup } from './features/credential-backup.js';
 import { isApprovalPayload, approvalStubs } from './features/approval-utils.js';
 import { qqbotOnboardingAdapter } from './features/onboarding.js';
 import { stripMentionText } from './utils/mention.js';
@@ -119,15 +119,12 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         cfg, sectionKey: 'qqbot', accountId,
         clearBaseFields: ['appId', 'clientSecret', 'clientSecretFile', 'name'],
       }),
-    isConfigured: (account) => {
-      if (account?.appId && account?.clientSecret) return true;
-      return loadCredentialBackup(account?.accountId) !== null;
-    },
+    isConfigured: (account) => isQQBotAccountConfigured(account),
     describeAccount: (account) => ({
       accountId: account?.accountId ?? DEFAULT_ACCOUNT_ID,
       name: account?.name,
       enabled: account?.enabled ?? false,
-      configured: Boolean(account?.appId && account?.clientSecret),
+      configured: isQQBotAccountConfigured(account),
       tokenSource: account?.secretSource,
     }),
     resolveAllowFrom: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string | null }) => {
@@ -306,7 +303,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
       accountId: account?.accountId ?? DEFAULT_ACCOUNT_ID,
       name: account?.name,
       enabled: account?.enabled ?? false,
-      configured: Boolean(account?.appId && account?.clientSecret),
+      configured: isQQBotAccountConfigured(account),
       tokenSource: account?.secretSource,
       running: Boolean(runtime?.running ?? false),
       connected: Boolean(runtime?.connected ?? false),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import type { ResolvedQQBotAccount, QQBotAccountConfig, ToolPolicy, GroupConfig } from "./types.js";
 import type { OpenClawConfig, GroupPolicy } from "openclaw/plugin-sdk";
+import { loadCredentialBackup } from "./features/credential-backup.js";
 
 // ============ Agent-aware mentionPatterns 解析 ============
 
@@ -199,13 +200,13 @@ export function listQQBotAccountIds(cfg: OpenClawConfig): string[] {
   const ids = new Set<string>();
   const qqbot = cfg.channels?.qqbot as QQBotChannelConfig | undefined;
 
-  if (qqbot?.appId) {
+  if (isQQBotAccountDiscoverable(cfg, DEFAULT_ACCOUNT_ID)) {
     ids.add(DEFAULT_ACCOUNT_ID);
   }
 
   if (qqbot?.accounts) {
     for (const accountId of Object.keys(qqbot.accounts)) {
-      if (qqbot.accounts[accountId]?.appId) {
+      if (isQQBotAccountDiscoverable(cfg, accountId)) {
         ids.add(accountId);
       }
     }
@@ -218,19 +219,28 @@ export function listQQBotAccountIds(cfg: OpenClawConfig): string[] {
  * 获取默认账户 ID
  */
 export function resolveDefaultQQBotAccountId(cfg: OpenClawConfig): string {
-  const qqbot = cfg.channels?.qqbot as QQBotChannelConfig | undefined;
-  // 如果有默认账户配置，返回 default
-  if (qqbot?.appId) {
+  const accountIds = listQQBotAccountIds(cfg);
+  if (accountIds.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }
-  // 否则返回第一个配置的账户
-  if (qqbot?.accounts) {
-    const ids = Object.keys(qqbot.accounts);
-    if (ids.length > 0) {
-      return ids[0];
-    }
+  return accountIds[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+/** Return whether a known account has any credential source that can start it. */
+function isQQBotAccountDiscoverable(cfg: OpenClawConfig, accountId: string): boolean {
+  const account = resolveQQBotAccount(cfg, accountId);
+  return Boolean(account.appId) || loadCredentialBackup(accountId) !== null;
+}
+
+/** Return whether an account has complete credentials now or can recover them from backup. */
+export function isQQBotAccountConfigured(account?: ResolvedQQBotAccount): boolean {
+  if (!account) {
+    return false;
   }
-  return DEFAULT_ACCOUNT_ID;
+  if (account.appId && account.clientSecret) {
+    return true;
+  }
+  return loadCredentialBackup(account.accountId) !== null;
 }
 
 /**

--- a/src/features/onboarding.ts
+++ b/src/features/onboarding.ts
@@ -8,7 +8,12 @@ import type {
   ChannelOnboardingAdapter,
   OpenClawConfig,
 } from 'openclaw/plugin-sdk';
-import { DEFAULT_ACCOUNT_ID, listQQBotAccountIds, resolveQQBotAccount } from '../config.js';
+import {
+  DEFAULT_ACCOUNT_ID,
+  isQQBotAccountConfigured,
+  listQQBotAccountIds,
+  resolveQQBotAccount,
+} from '../config.js';
 
 /**
  * Onboarding adapter — 导出给 ChannelPlugin 使用
@@ -25,7 +30,7 @@ export const qqbotOnboardingAdapter: ChannelOnboardingAdapter = {
     }
     const firstAccount = resolveQQBotAccount(cfg, accountIds[0]);
     return {
-      configured: Boolean(firstAccount.appId && firstAccount.clientSecret),
+      configured: isQQBotAccountConfigured(firstAccount),
       accountCount: accountIds.length,
       defaultAccountId: accountIds[0],
     };

--- a/src/setup/surface.ts
+++ b/src/setup/surface.ts
@@ -3,7 +3,12 @@
  */
 import type { ChannelSetupWizard } from '../adapter/setup.js';
 import { createStandardChannelSetupStatus, setSetupChannelEnabled } from '../adapter/setup.js';
-import { listQQBotAccountIds, resolveQQBotAccount, resolveDefaultQQBotAccountId } from '../config.js';
+import {
+  isQQBotAccountConfigured,
+  listQQBotAccountIds,
+  resolveQQBotAccount,
+  resolveDefaultQQBotAccountId,
+} from '../config.js';
 import { finalizeQQBotSetup } from './finalize.js';
 
 const CHANNEL = 'qqbot' as const;
@@ -21,7 +26,7 @@ export const qqbotSetupWizard: ChannelSetupWizard = {
     resolveConfigured: ({ cfg, accountId }) =>
       (accountId ? [accountId] : listQQBotAccountIds(cfg as any)).some((id) => {
         const account = resolveQQBotAccount(cfg as any, id);
-        return Boolean(account.appId && account.clientSecret);
+        return isQQBotAccountConfigured(account);
       }),
   }),
   // 未配置时默认使用 default 账号，有账户时框架会提示选择

--- a/tests/account-discovery.test.ts
+++ b/tests/account-discovery.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const credentialBackup = vi.hoisted(() => ({
+  load: vi.fn<(accountId?: string) => { accountId: string; appId: string; clientSecret: string; savedAt: string } | null>(),
+}));
+
+vi.mock('../src/features/credential-backup.js', () => ({
+  loadCredentialBackup: credentialBackup.load,
+}));
+
+import {
+  isQQBotAccountConfigured,
+  listQQBotAccountIds,
+  resolveQQBotAccount,
+  resolveDefaultQQBotAccountId,
+} from '../src/config.js';
+import { qqbotPlugin } from '../src/channel.js';
+import { qqbotOnboardingAdapter } from '../src/features/onboarding.js';
+import { qqbotSetupWizard } from '../src/setup/surface.js';
+
+const backupFor = (accountId: string) => ({
+  accountId,
+  appId: 'backup-app',
+  clientSecret: 'backup-secret',
+  savedAt: '2026-09-11T00:00:00.000Z',
+});
+
+describe('QQ Bot account discovery', () => {
+  const originalAppId = process.env.QQBOT_APP_ID;
+
+  beforeEach(() => {
+    delete process.env.QQBOT_APP_ID;
+    credentialBackup.load.mockReset().mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    if (originalAppId === undefined) {
+      delete process.env.QQBOT_APP_ID;
+    } else {
+      process.env.QQBOT_APP_ID = originalAppId;
+    }
+  });
+
+  it('discovers the default account from environment credentials', () => {
+    process.env.QQBOT_APP_ID = 'env-app';
+
+    expect(listQQBotAccountIds({ channels: { qqbot: { enabled: true } } } as never)).toEqual([
+      'default',
+    ]);
+  });
+
+  it('discovers and reports the default account from a recoverable backup', async () => {
+    credentialBackup.load.mockImplementation((accountId) =>
+      accountId === 'default' ? backupFor('default') : null,
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          enabled: true,
+          accounts: {
+            named: { appId: 'named-app', clientSecret: 'named-secret' },
+          },
+        },
+      },
+    } as never;
+
+    expect(listQQBotAccountIds(cfg)).toEqual(['default', 'named']);
+    expect(resolveDefaultQQBotAccountId(cfg)).toBe('default');
+    const account = resolveQQBotAccount(cfg, 'default');
+    expect(isQQBotAccountConfigured(account)).toBe(true);
+    const snapshot = await qqbotPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: {},
+    } as never);
+    expect(snapshot).toMatchObject({ configured: true });
+    const onboardingStatus = await qqbotOnboardingAdapter.getStatus?.({ config: cfg } as never);
+    expect(onboardingStatus).toMatchObject({
+      configured: true,
+      accountCount: 2,
+      defaultAccountId: 'default',
+    });
+    expect(qqbotSetupWizard.status.resolveConfigured({ cfg, accountId: 'default' })).toBe(true);
+  });
+
+  it('discovers a configured account whose credentials are recoverable from backup', () => {
+    credentialBackup.load.mockImplementation((accountId) =>
+      accountId === 'ops' ? backupFor('ops') : null,
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          enabled: true,
+          accounts: {
+            ops: { enabled: true },
+          },
+        },
+      },
+    } as never;
+
+    expect(listQQBotAccountIds(cfg)).toEqual(['ops']);
+    expect(resolveDefaultQQBotAccountId(cfg)).toBe('ops');
+    expect(isQQBotAccountConfigured(resolveQQBotAccount(cfg, 'ops'))).toBe(true);
+  });
+
+  it('does not invent an unknown account from an unrelated backup', () => {
+    credentialBackup.load.mockImplementation((accountId) =>
+      accountId === 'orphan' ? backupFor('orphan') : null,
+    );
+
+    expect(listQQBotAccountIds({ channels: { qqbot: { enabled: true } } } as never)).toEqual([]);
+    expect(isQQBotAccountConfigured()).toBe(false);
+  });
+});


### PR DESCRIPTION
Related context: openclaw/openclaw#138947

This PR addresses only QQ Bot account discovery and does not close or claim to resolve the broader OpenClaw issue.

## What Problem This Solves

Fixes an issue where a QQ Bot account that can start from environment credentials or the plugin's credential backup may remain invisible to OpenClaw account discovery. In that state the gateway can recover and start the bot, while status and default-account selection still treat it as absent or unconfigured.

## Why This Change Was Made

Account enumeration and default-account selection now use the same supported credential sources as account resolution and lifecycle recovery. The plugin also uses one backup-aware configured check for startup gating, account descriptions, runtime status snapshots, onboarding, and setup status, so these surfaces cannot disagree about the same recoverable account.

Unknown backup account IDs are not invented: named accounts still need an entry in `channels.qqbot.accounts`, while the default account may be discovered from the documented default environment or backup sources.

## User Impact

Operators can restart or reload QQ Bot without a recovered account disappearing from OpenClaw's account list or being reported as unconfigured after the plugin has restored its credentials.

## Evidence

- Source regression coverage for environment-only default accounts, backup-backed default accounts, backup-backed named accounts, default selection, runtime/onboarding/setup configured reporting, and unrelated backups.
- CodeRabbit's initial runtime-snapshot consistency finding was fixed in exact head `8c8aa2c` and the same audit was applied to onboarding and setup status.
- `vitest run tests/account-discovery.test.ts tests/account-key.test.ts --maxWorkers=1 --no-file-parallelism`: 20 tests passed.
- `npm run typecheck`: passed.
- `npm run build`: passed, including declaration generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - QQ Bot accounts can now be discovered and selected using configured app credentials or recoverable credential backups.
  - Default account discovery includes accounts whose credentials can be restored from backup.

- **Bug Fixes**
  - QQ Bot configuration status is now reported consistently across account management, onboarding, and setup.
  - Unrelated credential backups no longer create unknown or unintended accounts.
  - Account descriptions and snapshots now accurately reflect whether credentials are available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->